### PR TITLE
Added the ability to create forms with HS ticket numbers directly.

### DIFF
--- a/admin-bar-form-manager.php
+++ b/admin-bar-form-manager.php
@@ -218,13 +218,23 @@ class GW_Admin_Bar_Form_Manager {
 
 					subMenu.html( '' );
 
-					listItems.filter( function() {
+					var $filteredList = listItems.filter( function() {
 
 						var search = searchInput.val(),
 							regex  = new RegExp( search, 'i' );
 
+						// Always show "Add New" commands if search is numeric (and modify links accordingly)
+						var $this = $( this );
+						if ( $this.text().indexOf( 'cmd: Add' ) === 0 ) {
+							if ( search && search.match(/^[0-9]*$/) ) {
+								$this.find('span').after( "<span> ({0})</span>".format( search ) );
+								$this.find('a').get(0).href += "&formTitle={0}".format( encodeURIComponent( search ) );
+								return true;
+							}
+						}
 						return regex.test( $( this ).text() );
-					} ).appendTo( subMenu );
+					} );
+					$filteredList.appendTo( subMenu );
 
 				}
 

--- a/admin-bar-form-manager.php
+++ b/admin-bar-form-manager.php
@@ -227,8 +227,8 @@ class GW_Admin_Bar_Form_Manager {
 						var $this = $( this );
 						if ( $this.text().indexOf( 'cmd: Add' ) === 0 ) {
 							if ( search && search.match(/^[0-9]*$/) ) {
-								$this.find('span').after( "<span> ({0})</span>".format( search ) );
-								$this.find('a').get(0).href += "&formTitle={0}".format( encodeURIComponent( search ) );
+								$this.find('span').after('<span> (' + search + ')</span>');
+								$this.find('a').get(0).href += '&formTitle=' + encodeURIComponent( search );
 								return true;
 							}
 						}

--- a/includes/admin-bar-form-manager-new-form.php
+++ b/includes/admin-bar-form-manager-new-form.php
@@ -90,9 +90,9 @@ class GW_ABFM_New_Form {
 		if( absint( $result ) > 0 ) {
 
 			$form = $result['meta'];
-
+			$formTitle = rgget( 'formTitle' );
 			// Set form title to form title base + form ID.
-			$form['title'] = sprintf( '%s %s', $this->form_title_base, $form['id'] );
+			$form['title'] = empty( $formTitle ) ? sprintf( '%s %s', $this->form_title_base, $form['id'] ) : $formTitle;
 			$form['is_active'] = true;
 
 			GFAPI::update_form( $form );

--- a/includes/admin-bar-form-manager-new-nested-form.php
+++ b/includes/admin-bar-form-manager-new-nested-form.php
@@ -134,11 +134,15 @@ class GW_ABFM_New_Nested_Form {
 		if ( absint( $result ) > 0 ) {
 
 			$form = $result['meta'];
-
+			$formTitle = rgget( 'formTitle' );
 			// Set form title to form title base + form ID.
 			$base              = $child_form_id ? 'Parent' : 'Child';
 			$title_form_id     = $child_form_id ? $child_form_id : $form['id'];
-			$form['title']     = sprintf( '%s %s', $base, $title_form_id );
+			if ( ! empty( $formTitle ) ) {
+				$form['title'] = sprintf( '%s %s', $formTitle, $base );
+			} else {
+				$form['title'] = sprintf( '%s %s', $base, $title_form_id );
+			}
 			$form['is_active'] = true;
 
 			GFAPI::update_form( $form );


### PR DESCRIPTION
This PR adds the ability to name newly created forms or nested forms to follow their HS number.

I find that numbering everything (including local sites) improves my productivity as I'm not searching by a client's imported site name, specific issue or a generic "Parent"/"Form 321".

It's currently limited to numbers and will offer you to create new forms and nested forms using those number that should match the HS ticket number.

Here's a [screen recording of this PR in action](https://www.loom.com/share/70141fe486cb4375a6b2a70c697a379c).