### PR TITLE
Fixed PHP 8 warnings.

### DIFF
--- a/includes/admin-bar-form-manager-new-form.php
+++ b/includes/admin-bar-form-manager-new-form.php
@@ -112,8 +112,12 @@ class GW_ABFM_New_Form {
 		$field_type_labels = array();
 		foreach ( $field_types as $field_type ) {
 			$field_title = $field_type->get_form_editor_field_title();
-			if ( $field_title ) {
+			// Check if $field_title is not null before using ucwords
+			if ( $field_title !== null ) {
 				$field_type_labels[ $field_type->type ] = ucwords( $field_title );
+			} else {
+				// Handle the case where the title is null, if necessary
+				$field_type_labels[ $field_type->type ] = 'Untitled';
 			}
 		}
 


### PR DESCRIPTION
Just something came up while updating...

PHP 8.2.x Warning

 Deprecated: ucwords(): Passing null to parameter #1 ($string) of type string is deprecated in /.../mu-plugins/admin-bar-form-manager/includes/admin-bar-form-manager-new-form.php on L116